### PR TITLE
feat: allow runtime tuning of controller sensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Hardware you need:
 | RT | Zoom in |
 | LT | Zoom out |
 | LB | Cycle to next camera |
+| D-pad up/down | Increase/decrease max speed |
+| D-pad right/left | Increase/decrease dead-zone |
 
 ## Customising after install
 
@@ -44,7 +46,7 @@ export PTZ_CAMS=192.168.10.100,192.168.10.101
 export PTZ_PORT=5678
 ```
 
-- Adjust speed / dead-zone: edit `MAX_SPEED` and `DEADZONE` constants in `/home/pi/ptzpad.py`.
+- Adjust speed / dead-zone: use the D-pad (up/down for `MAX_SPEED`, right/left for `DEADZONE`) or edit the constants in `/home/pi/ptzpad.py`.
 
 ## Service management
 

--- a/install.sh
+++ b/install.sh
@@ -65,6 +65,25 @@ while True:
         time.sleep(0.25)          # debounce
         print(">> Control switched to CAM", cur+1, CAMS[cur])
 
+    # D-pad adjustments for speed and dead-zone
+    hx, hy = js.get_hat(0)
+    if hy == 1:
+        MAX_SPEED = min(MAX_SPEED + 1, 0x18)
+        print(f">> MAX_SPEED set to {MAX_SPEED}")
+        time.sleep(0.25)
+    elif hy == -1:
+        MAX_SPEED = max(MAX_SPEED - 1, 1)
+        print(f">> MAX_SPEED set to {MAX_SPEED}")
+        time.sleep(0.25)
+    if hx == 1:
+        DEADZONE = min(DEADZONE + 0.05, 0.9)
+        print(f">> DEADZONE set to {DEADZONE:.2f}")
+        time.sleep(0.25)
+    elif hx == -1:
+        DEADZONE = max(DEADZONE - 0.05, 0.0)
+        print(f">> DEADZONE set to {DEADZONE:.2f}")
+        time.sleep(0.25)
+
     ip = CAMS[cur]
     x, y = js.get_axis(0), -js.get_axis(1)   # left stick (invert Y)
     if abs(x) > DEADZONE or abs(y) > DEADZONE:


### PR DESCRIPTION
## Summary
- add D-pad controls to tune MAX_SPEED and DEADZONE at runtime
- document D-pad mappings for speed and dead-zone adjustments

## Testing
- `bash -n install.sh`
- `python3 -m py_compile ptzpad_temp.py`

------
https://chatgpt.com/codex/tasks/task_e_68938c0dae40832cb42e2f385a228b64