### PR TITLE
feat: add graceful termination handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ sudo systemctl restart ptzpad
 sudo journalctl -u ptzpad -f   # live logs
 ```
 
+The bridge handles `SIGTERM`/`SIGINT`, allowing `systemctl stop ptzpad` or `Ctrl+C` to terminate it quickly.
+
 ## Troubleshooting
 
 | Symptom | Fix |

--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,7 @@ User=${TARGET_USER}
 ExecStart=/usr/bin/python3 ${TARGET_HOME}/ptzpad.py
 Restart=on-failure
 Environment="PTZ_CAMS=%i"
+TimeoutStopSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/ptzpad.py
+++ b/ptzpad.py
@@ -1,14 +1,26 @@
 #!/usr/bin/env python3
 # Xbox-One → PTZOptics VISCA-over-IP bridge
-import pygame, socket, time, os, sys
+import pygame, socket, time, os, sys, signal
 
 # ---- CONFIG ---------------------------------------------------------------
 CAMS = os.environ.get("PTZ_CAMS", "192.168.1.150").split(",")  # env override
 CAM_PORT = int(os.environ.get("PTZ_PORT", "5678"))
 MAX_SPEED = 0x18                 # 0x01 (slow) … 0x18 (fast)
-DEADZONE  = 0.15                 # stick slack
-LOOP_MS   = 50                   # command period (ms)
+DEADZONE = 0.15                 # stick slack
+LOOP_MS = 50                    # command period (ms)
 # ---------------------------------------------------------------------------
+
+running = True
+
+
+def handle_signal(signum, frame):
+    """Flip running flag to exit main loop."""
+    global running
+    running = False
+
+
+signal.signal(signal.SIGTERM, handle_signal)
+signal.signal(signal.SIGINT, handle_signal)
 
 pygame.init()
 if pygame.joystick.get_count() == 0:
@@ -61,7 +73,7 @@ def zoom(cmd, ip):                # cmd: b'\x2F' tele, b'\x3F' wide, b'\x00' sto
     send(b"\x81\x01\x04\x07" + cmd + b"\xFF", ip)
 
 print(">>> PTZ bridge running.  Cameras:", ", ".join(CAMS))
-while True:
+while running:
     pygame.event.pump()
     # camera cycling – LB button (#4)
     if js.get_button(4):
@@ -105,3 +117,5 @@ while True:
         zoom(b"\x00", ip)        # stop zoom
 
     time.sleep(LOOP_MS / 1000)
+
+pygame.quit()


### PR DESCRIPTION
## Summary
- handle SIGTERM/SIGINT in `ptzpad.py` and quit pygame cleanly
- speed up service shutdown by setting `TimeoutStopSec` in `install.sh`
- document signal handling and quicker exit in README

## Testing
- `python -m py_compile ptzpad.py`
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_6893b028b5d4832cba70e864701d0a4f