### PR TITLE
fix: correct trigger axis mapping for zoom control

### DIFF
--- a/ptzpad.py
+++ b/ptzpad.py
@@ -93,9 +93,13 @@ while True:
     else:
         visca_stop(ip)
 
-    rt, lt = js.get_axis(5), js.get_axis(2)  # triggers
-    if rt < -0.3:   zoom(b"\x2F", ip)        # zoom tele
-    elif lt < -0.3: zoom(b"\x3F", ip)        # zoom wide
-    else:           zoom(b"\x00", ip)        # stop zoom
+    rt = (js.get_axis(4) + 1) / 2  # right trigger (0..1)
+    lt = (js.get_axis(5) + 1) / 2  # left trigger (0..1)
+    if rt > 0.3:
+        zoom(b"\x2F", ip)        # zoom tele
+    elif lt > 0.3:
+        zoom(b"\x3F", ip)        # zoom wide
+    else:
+        zoom(b"\x00", ip)        # stop zoom
 
     time.sleep(LOOP_MS / 1000)


### PR DESCRIPTION
## Summary
- map zoom controls to axes 4 (RT) and 5 (LT) so triggers work independently

## Testing
- `python -m py_compile ptzpad.py`


------
https://chatgpt.com/codex/tasks/task_e_6893aa870868832c8b4e6606a3cea256