### PR TITLE
feat: apply logarithmic pan tilt scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Hardware you need:
 
 | Input | Action |
 |-------|--------|
-| Right stick | Pan / tilt (speed scales with stick deflection) |
+| Right stick | Pan / tilt (speed scales logarithmically with stick deflection) |
 | Left stick up/down | Focus far/near (medium deadzone) |
 | Left stick click | One-time autofocus |
 | RT | Zoom in |

--- a/ptzpad.py
+++ b/ptzpad.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Xbox-One → PTZOptics VISCA-over-IP bridge
-import pygame, socket, time, os, sys, signal
+import pygame, socket, time, os, sys, signal, math
 
 # ---- CONFIG ---------------------------------------------------------------
 def parse_cams() -> list[tuple[str, str, int]]:
@@ -69,10 +69,11 @@ def send(pkt, cam):
 def visca_move(x, y, cam):
     """Drive pan/tilt according to joystick input."""
     def speed(v: float) -> int:
-        # Scale speed with stick deflection for finer control
+        # Scale speed with stick deflection using a logarithmic curve for finer control
         norm = (abs(v) - deadzone) / (1 - deadzone)
         norm = max(0.0, min(norm, 1.0))
-        return max(1, int(norm * (max_speed - 1)) + 1)
+        curve = math.log10(norm * 9 + 1)
+        return max(1, int(curve * (max_speed - 1)) + 1)
 
     pan_dir = 0x03
     tilt_dir = 0x03


### PR DESCRIPTION
## Summary
- refine pan/tilt speed by mapping stick deflection to a logarithmic curve
- document logarithmic scaling in the default controls

## Testing
- `python -m py_compile ptzpad.py`


------
https://chatgpt.com/codex/tasks/task_e_6895003bde8c832c9cbf598d79b0399a