### PR TITLE
docs: add uninstall instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,11 @@ The bridge handles `SIGTERM`/`SIGINT`, allowing `systemctl stop ptzpad` or `Ctrl
 - Expand controller mapping to handle additional buttons or advanced behaviors.
 - Learn more about `systemd` for tuning how the service runs and logs.
 
+## Uninstall
+
+```bash
+sudo systemctl disable --now ptzpad
+sudo rm /etc/systemd/system/ptzpad.service
+```
+
+Delete `~/ptzpad.py` if it's no longer needed.


### PR DESCRIPTION
## Summary
- document how to disable and remove ptzpad systemd service
- mention optional removal of ptzpad script

## Testing
- `python -m py_compile ptzpad.py && echo py_compile_ok`
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68950363dc1c832cb83981789865c2bb