### PR TITLE
docs: mention PTZ_CAMS override in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ cd XboxPTZControl
 sudo bash install.sh            # edit CAMS array at top if needed
 ```
 
+Camera addresses can be changed by editing the `CAMS` array at the top of `install.sh` or by exporting the `PTZ_CAMS` environment variable before running the service, for example:
+
+```bash
+export PTZ_CAMS=tcp:192.168.10.44,udp:192.168.10.54
+```
+
 Hardware you need:
 
 - Raspberry Pi 3 B or newer running Raspberry Pi OS (32-bit, bullseye or bookworm)


### PR DESCRIPTION
## Summary
- document how to change camera addresses via `install.sh` or `PTZ_CAMS`
- show example `PTZ_CAMS` export in Quick start section

## Testing
- `python -m py_compile ptzpad.py`
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_689503645950832c95c596a77cb88bba