### PR TITLE
feat: smooth joystick ramp with cubic curve

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Hardware you need:
 
 | Input | Action |
 |-------|--------|
-| Right stick | Pan / tilt (speed scales logarithmically with stick deflection for a longer ramp) |
+| Right stick | Pan / tilt (speed scales with a cubic curve for a smoother ramp) |
 | Left stick up/down | Focus far/near (medium deadzone) |
 | Left stick click | One-time autofocus |
 | RT | Zoom in |

--- a/ptzpad.py
+++ b/ptzpad.py
@@ -69,10 +69,10 @@ def send(pkt, cam):
 def visca_move(x, y, cam):
     """Drive pan/tilt according to joystick input."""
     def speed(v: float) -> int:
-        # Scale speed with stick deflection using a gentler logarithmic curve for an extended ramp
+        # Scale speed with stick deflection using a cubic curve for a very smooth ramp
         norm = (abs(v) - deadzone) / (1 - deadzone)
         norm = max(0.0, min(norm, 1.0))
-        curve = math.log10(norm * 3 + 1) / math.log10(4)
+        curve = norm ** 3
         return max(1, int(curve * (max_speed - 1)) + 1)
 
     pan_dir = 0x03


### PR DESCRIPTION
## Summary
- use cubic curve to scale pan/tilt speed for smoother joystick ramp
- document new ramp behavior in README

## Testing
- `python -m py_compile ptzpad.py`


------
https://chatgpt.com/codex/tasks/task_e_689518da1118832c9b630ae3e69f70b6