### PR TITLE
feat: add zoom trigger deadzone

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ export PTZ_CAMS=tcp:192.168.10.44,udp:192.168.10.54
 # format: proto:ip[:port] (defaults 5678 TCP, 1259 UDP)
 ```
 
-- Adjust speed / dead-zone / zoom speed: use the D-pad or RB/LB bumpers, or edit `MAX_SPEED`, `DEADZONE` and `MAX_ZOOM_SPEED` in `~/ptzpad.py`.
+- Adjust speed / dead-zone / zoom speed / zoom dead-zone: use the D-pad or RB/LB bumpers, or edit `MAX_SPEED`, `DEADZONE`, `MAX_ZOOM_SPEED` and `ZOOM_DEADZONE` in `~/ptzpad.py`.
 
 ## Service management
 


### PR DESCRIPTION
## Summary
- add `ZOOM_DEADZONE` to filter trigger noise
- track last zoom direction and send commands only when direction changes
- document new zoom dead-zone setting

## Testing
- `python -m py_compile ptzpad.py`


------
https://chatgpt.com/codex/tasks/task_e_68951c4ae190832ca45a18f9cd100d88