### PR TITLE
fix jittery zoom by resending command each loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The bridge handles `SIGTERM`/`SIGINT`, allowing `systemctl stop ptzpad` or `Ctrl
 | `pygame.error: No joystick` | Check USB cable/port; `lsusb` should list the Xbox controller. |
 | `Connection refused` | Wrong port or VISCA-TCP disabled in camera web UI. |
 | Jerky / slow moves | Keep ≥40 ms between VISCA packets (`LOOP_MS`), use wired LAN. |
+| Zoom jitter or stops while holding trigger | Increase `ZOOM_DEADZONE` to filter trigger noise. |
 | Lag after 30 s idle | Some cameras drop idle TCP; the script sends periodic keep-alives – ensure they aren’t blocked by a firewall. |
 
 ## Where to go next

--- a/ptzpad.py
+++ b/ptzpad.py
@@ -192,9 +192,10 @@ while running:
     else:
         zoom_dir = 0
 
-    if zoom_dir != last_zoom_dir:   # send only on change
+    # resend zoom command while trigger held so camera keeps moving
+    if zoom_dir != last_zoom_dir or zoom_dir != 0:
         zoom(zoom_dir, cam)
-        last_zoom_dir = zoom_dir
+    last_zoom_dir = zoom_dir
 
     time.sleep(LOOP_MS / 1000)
 


### PR DESCRIPTION
## Summary
- Resend zoom command while trigger held to maintain continuous zoom
- Document zoom jitter fix in troubleshooting

## Testing
- `python -m py_compile ptzpad.py`


------
https://chatgpt.com/codex/tasks/task_e_68951b72fcbc832c992ec97284af1f53