### PR TITLE
fix: repeat zoom command while trigger held

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Hardware you need:
 | Right stick | Pan / tilt (speed scales with a cubic curve for a smoother ramp) |
 | Left stick up/down | Focus far/near (medium deadzone) |
 | Left stick click | One-time autofocus |
-| RT | Zoom in |
-| LT | Zoom out |
+| RT | Zoom in (repeats while held) |
+| LT | Zoom out (repeats while held) |
 | A | Cycle to next camera |
 | D-pad up/down | Increase / decrease max speed |
 | D-pad left/right | Increase / decrease deadzone |
@@ -74,7 +74,7 @@ The bridge handles `SIGTERM`/`SIGINT`, allowing `systemctl stop ptzpad` or `Ctrl
 | Service prints `Waiting for joystick connection…` | Check USB cable/port; `lsusb` should list the Xbox controller. |
 | `Connection refused` | Wrong port or VISCA-TCP disabled in camera web UI. |
 | Jerky / slow moves | Keep ≥40 ms between VISCA packets (`LOOP_MS`), use wired LAN. |
-| Zoom jitter or stops while holding trigger | Increase `ZOOM_DEADZONE` to filter trigger noise. |
+| Zoom jitter or stops while holding trigger | Increase `ZOOM_DEADZONE` to filter trigger noise. Zoom commands repeat while the trigger is held. |
 | Lag after 30 s idle | Some cameras drop idle TCP; the script sends periodic keep-alives – ensure they aren’t blocked by a firewall. |
 
 ## Where to go next

--- a/ptzpad.py
+++ b/ptzpad.py
@@ -212,10 +212,12 @@ while running:
     else:
         zoom_dir = 0
 
-    # send zoom command only when trigger direction changes
-    if zoom_dir != last_zoom_dir:
+    # continuously send zoom commands while trigger held; send stop once on release
+    if zoom_dir != 0:
         zoom(zoom_dir, cam)
-        last_zoom_dir = zoom_dir
+    elif last_zoom_dir != 0:
+        zoom(0, cam)
+    last_zoom_dir = zoom_dir
 
     time.sleep(LOOP_MS / 1000)
 


### PR DESCRIPTION
## Summary
- ensure zoom command repeats while trigger held and stop sent once on release
- document continuous zoom behavior in README

## Testing
- `python -m py_compile ptzpad.py`


------
https://chatgpt.com/codex/tasks/task_e_689656e35118832c9e39cde68d227c0a