### PR TITLE
Enforce static OLED status override

### DIFF
--- a/oled_status.py
+++ b/oled_status.py
@@ -43,6 +43,7 @@ class OledStatus:
         self._last_update = 0.0
         self._failed_once = False
         self._available = False
+        self._override_lines = ["Out of Service", "Try again later"]  # Temporary static message
 
         if not all([canvas, i2c, ssd1306, ImageFont]):
             self._display = _NullDisplay()
@@ -121,7 +122,9 @@ class OledStatus:
         if not self.available:
             return
 
-        normalized = [line[:21] for line in lines]  # 21 chars fits default font
+        _ = lines  # Ignored while override message is active
+        override_lines = self._override_lines
+        normalized = [line[:21] for line in override_lines]  # 21 chars fits default font
         now = time.time()
         if not force:
             if normalized == self._last_lines:


### PR DESCRIPTION
## Summary
- add a static override message when initializing the OLED status display
- render the fixed two-line message in all OLED updates and keepalive cycles

## Testing
- python -m py_compile oled_status.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69343e294804832c900338e59f8486fd)